### PR TITLE
fix multithread bug

### DIFF
--- a/src/Models/recursive_bp_factor.jl
+++ b/src/Models/recursive_bp_factor.jl
@@ -119,8 +119,9 @@ function onebpiter!(bp::MPBP{G,F}, i::Integer, ::Type{U};
     C, full, logzᵢ = compute_prob_ys(wᵢ, nstates(bp,i), μ[ein.|>idx], ψ[eout.|>idx], getT(bp), svd_trunc)
     for (j,e) = enumerate(eout)
         B = f_bp_partial_ij(C[j], wᵢ, ϕᵢ, dᵢ - 1, nstates(bp, dst(e)), j)
-        μ[idx(e)] = sweep_RtoL!(mpem2(B); svd_trunc, verbose=svd_verbose)
-        logzᵢ += normalize!(μ[idx(e)])
+        μj = sweep_RtoL!(mpem2(B); svd_trunc, verbose=svd_verbose)
+        logzᵢ += normalize!(μj)
+        μ[idx(e)] = μj
     end
     B = f_bp_partial_i(full, wᵢ, ϕᵢ, dᵢ)
     bp.b[i] = B |> mpem2 |> marginalize

--- a/src/mpbp.jl
+++ b/src/mpbp.jl
@@ -90,9 +90,10 @@ function onebpiter!(bp::MPBP, i::Integer, ::Type{U};
     for (j_ind, e_out) in enumerate(eout)
         B, logzᵢ₂ⱼ = f_bp(A, w[i], ϕ[i], ψ[eout.|>idx], j_ind; svd_trunc)
         C = mpem2(B)
-        μ[idx(e_out)] = sweep_RtoL!(C; svd_trunc, verbose=svd_verbose)
-        logzᵢ₂ⱼ += normalize!(μ[idx(e_out)])
+        μj = sweep_RtoL!(C; svd_trunc, verbose=svd_verbose)
+        logzᵢ₂ⱼ += normalize!(μj)
         logzᵢ += logzᵢ₂ⱼ
+        μ[idx(e_out)] = μj
     end
     dᵢ = length(ein)
     bp.b[i] = onebpiter_dummy_neighbor(bp, i; svd_trunc) |> marginalize


### PR DESCRIPTION
`normalize!(μ[idx(e)])` was called, but another thread could be in the middle of computations with that message. We should never modify a message in-place: instead, we should modify a copy of the message and then update it with `μ[idx(e)] = ...`