### PR TITLE
Get rid of `getT(::MPEM)`

### DIFF
--- a/src/MatrixProductBP.jl
+++ b/src/MatrixProductBP.jl
@@ -41,7 +41,7 @@ include("atomic_vector.jl")
 include("MPEMs/MPEMs.jl")
 using .MPEMs, Reexport
 @reexport import .MPEMs: SVDTrunc, TruncBond, TruncThresh, TruncBondMax, TruncBondThresh, 
-    summary_compact, normalize_eachmatrix!, -, isapprox, evaluate, getT, bond_dims,
+    summary_compact, normalize_eachmatrix!, -, isapprox, evaluate, bond_dims,
     MPEM, MPEM2, MPEM3, MatrixProductTrain, mpem2, rand_mpem2, sweep_RtoL!, sweep_LtoR!,
     compress!, accumulate_L, accumulate_R, accumulate_M, firstvar_marginal,
     marginals, marginals_tu, mpem1,

--- a/src/Models/recursive_bp_factor.jl
+++ b/src/Models/recursive_bp_factor.jl
@@ -69,7 +69,7 @@ function _f_bp_partial(A::MPEM2, wᵢ::Vector{U}, ϕᵢ,
     d::Integer, prob::Function, qj, j) where {U<:RecursiveBPFactor}
     q = length(ϕᵢ[1])
     B = [zeros(size(a,1), size(a,2), q, qj, q) for a in A]
-    for t in 1:getT(A)
+    for t in 1:length(A)-1
         Aᵗ,Bᵗ = A[t], B[t]
         @tullio Bᵗ[m,n,xᵢᵗ,xⱼᵗ,xᵢᵗ⁺¹] = prob(wᵢ[$t],xᵢᵗ⁺¹,xᵢᵗ,xⱼᵗ,yᵗ,d,j)*Aᵗ[m,n,yᵗ,xᵢᵗ]*ϕᵢ[$t][xᵢᵗ]
     end

--- a/src/mpbp.jl
+++ b/src/mpbp.jl
@@ -23,15 +23,15 @@ struct MPBP{G<:AbstractIndexedDiGraph, F<:Real, V<:AbstractVector{<:BPFactor}}
         @assert check_ψs(ψ, g)
         @assert all( length(ϕᵢ) == T + 1 for ϕᵢ in ϕ )
         @assert all( length(ψᵢ) == T + 1 for ψᵢ in ψ )
-        @assert all( getT(μᵢⱼ) == T for μᵢⱼ in μ)
-        @assert all( getT(bᵢ) == T for bᵢ in b )
+        @assert all( length(μᵢⱼ) == T + 1 for μᵢⱼ in μ)
+        @assert all( length(bᵢ) == T + 1 for bᵢ in b )
         @assert length(μ) == ne(g)
         normalize!.(μ)
         return new{G,F,V}(g, w, ϕ, ψ, AtomicVector(μ), b, f)
     end
 end
 
-getT(bp::MPBP) = getT(bp.b[1])
+getT(bp::MPBP) = length(bp.b[1]) - 1
 getN(bp::MPBP) = nv(bp.g)
 nstates(bp::MPBP, i) = nstates(bp.b[i])
 

--- a/test/mpem.jl
+++ b/test/mpem.jl
@@ -7,8 +7,7 @@ svd_trunc = TruncThresh(0.0)
 @testset "MPEM1" begin
     tensors = [rand(1,3,2), rand(3,4,2), rand(4,10,2), rand(10,1,2)]
     C = MPEM1(tensors)
-    T = getT(C)
-    x = [rand(1:2,1) for t in 1:T+1]
+    x = [rand(1:2,1) for _ in C]
     e1 = evaluate(C, x)
 
     sweep_RtoL!(C; svd_trunc)
@@ -26,8 +25,7 @@ end
 @testset "MPEM2" begin
     tensors = [rand(1,3,2,2), rand(3,4,2,2), rand(4,10,2,2), rand(10,1,2,2)]
     C = MPEM2(tensors)
-    T = getT(C)
-    x = [rand(1:2,2) for t in 1:T+1]
+    x = [rand(1:2,2) for _ in C]
     e1 = evaluate(C, x)
 
     sweep_RtoL!(C; svd_trunc)
@@ -45,7 +43,7 @@ end
     T = 5
     q1 = 2; q2 = 4
     C = rand_mpem2(q1, q2, T)
-    x = [[rand(1:q1), rand(1:q2)] for t in 1:T+1]
+    x = [[rand(1:q1), rand(1:q2)] for _ in C]
     e1 = evaluate(C, x)
 
     sweep_RtoL!(C; svd_trunc)
@@ -63,9 +61,8 @@ end
     tensors = [ rand(1,3,2,2,2), rand(3,4,2,2,2), rand(4,1,2,2,2) ]
     tensors[end][:,:,:,:,2] .= tensors[end][:,:,:,:,1]
     B = MPEM3(tensors)
-    T = getT(B)
 
-    x = [rand(1:2,2) for t in 1:T+1]
+    x = [rand(1:2,2) for _ in B]
     e1 = evaluate(B, x)
 
     C = mpem2(B)


### PR DESCRIPTION
Towards standalone module for MatrixProducts: avoid references to the interpretation of the indices as time steps $T=0,1,\ldots,T$