### PR TITLE
Multithreaded, lighter sampling

### DIFF
--- a/src/MatrixProductBP.jl
+++ b/src/MatrixProductBP.jl
@@ -16,7 +16,7 @@ import Statistics: mean, std
 import Unzip: unzip
 import StatsBase: weights, proportions
 import LogExpFunctions: logistic, logsumexp
-import .Threads: SpinLock, lock, unlock
+import .Threads: SpinLock, lock, unlock, @threads
 import Lazy: @forward
 import CavityTools: cavity
 import LogarithmicNumbers: ULogarithmic


### PR DESCRIPTION
Two improvements:
- Multithreaded sampling and computation of observables
- Store sampled values by default as `UInt8` instead of `Int` to use less memory