### PR TITLE
Restrict compact of CavityTools to prevent breaking changes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 Unzip = "41fe7b60-77ed-43a1-b4f0-825fd5a5650d"
 
 [compat]
-CavityTools = "0.3 - 1"
+CavityTools = "0.3"
 Distributions = "0.25"
 IndexedGraphs = "0.3, 0.4"
 InvertedIndices = "1"


### PR DESCRIPTION
As required by https://github.com/JuliaRegistries/General/pull/102260?notification_referrer_id=NT_kwDOArN9JbM5NzEzNjA5NjY3OjQ1MzE3NDEz#issuecomment-1977490708