### PR TITLE
Avoid a deepcopy when constructing MPBP from SIS

### DIFF
--- a/src/Models/epidemics/sirs_bp.jl
+++ b/src/Models/epidemics/sirs_bp.jl
@@ -17,10 +17,9 @@ nstates(::SIRSFactor, l::Integer) = l == 0 ? 1 : 2
 
 
 function mpbp(sirs::SIRS{T,N,F}; kw...) where {T,N,F}
-    sirs_ = deepcopy(sirs)
-    g = IndexedBiDiGraph(sirs_.g.A)
-    w = sirs_factors(sirs_)
-    return mpbp(g, w, fill(3, nv(g)), T, ϕ=sirs_.ϕ, ψ=sirs_.ψ; kw...)
+    g = IndexedBiDiGraph(sirs.g.A)
+    w = sirs_factors(sirs)
+    return mpbp(g, w, fill(3, nv(g)), T, ϕ=sirs.ϕ, ψ=sirs.ψ; kw...)
 end
 
 function prob_y(wᵢ::SIRSFactor, xᵢᵗ⁺¹, xᵢᵗ, yᵗ, d)

--- a/src/Models/epidemics/sis_bp.jl
+++ b/src/Models/epidemics/sis_bp.jl
@@ -37,17 +37,15 @@ function (fᵢ::SISFactor)(xᵢᵗ⁺¹::Integer, xₙᵢᵗ::AbstractVector{<:I
 end
 
 function mpbp(sis::SIS{T,N,F}; kw...) where {T,N,F}
-    sis_ = deepcopy(sis)
-    g = IndexedBiDiGraph(sis_.g.A)
-    w = sis_factors(sis_)
-    return mpbp(g, w, fill(2, nv(g)), T, ϕ=sis_.ϕ, ψ=sis_.ψ; kw...)
+    g = IndexedBiDiGraph(sis.g.A)
+    w = sis_factors(sis)
+    return mpbp(g, w, fill(2, nv(g)), T, ϕ=sis.ϕ, ψ=sis.ψ; kw...)
 end
 
 function periodic_mpbp(sis::SIS{T,N,F}; kw...) where {T,N,F}
-    sis_ = deepcopy(sis)
-    g = IndexedBiDiGraph(sis_.g.A)
-    w = sis_factors(sis_)
-    return periodic_mpbp(g, w, fill(2, nv(g)), T, ϕ=sis_.ϕ, ψ=sis_.ψ; kw...)
+    g = IndexedBiDiGraph(sis.g.A)
+    w = sis_factors(sis)
+    return periodic_mpbp(g, w, fill(2, nv(g)), T, ϕ=sis.ϕ, ψ=sis.ψ; kw...)
 end
 
 # neighbor j is susceptible -> does nothing

--- a/src/Models/epidemics/sis_heterogeneous_bp.jl
+++ b/src/Models/epidemics/sis_heterogeneous_bp.jl
@@ -40,17 +40,15 @@ function (fᵢ::SIS_heterogeneousFactor)(xᵢᵗ⁺¹::Integer, xᵗ::AbstractVe
 end
 
 function mpbp(sis::SIS_heterogeneous{T,N,F}; kw...) where {T,N,F}
-    sis_ = deepcopy(sis)
-    g = IndexedBiDiGraph(sis_.g.A)
-    w = sis_heterogeneous_factors(sis_)
-    return mpbp(g, w, fill(2, nv(g)), T, ϕ=sis_.ϕ, ψ=sis_.ψ; kw...)
+    g = IndexedBiDiGraph(sis.g.A)
+    w = sis_heterogeneous_factors(sis)
+    return mpbp(g, w, fill(2, nv(g)), T, ϕ=sis.ϕ, ψ=sis.ψ; kw...)
 end
 
 function periodic_mpbp(sis::SIS_heterogeneous{T,N,F}; kw...) where {T,N,F}
-    sis_ = deepcopy(sis)
-    g = IndexedBiDiGraph(sis_.g.A)
-    w = sis_heterogeneous_factors(sis_)
-    return periodic_mpbp(g, w, fill(2, nv(g)), T, ϕ=sis_.ϕ, ψ=sis_.ψ; kw...)
+    g = IndexedBiDiGraph(sis.g.A)
+    w = sis_heterogeneous_factors(sis)
+    return periodic_mpbp(g, w, fill(2, nv(g)), T, ϕ=sis.ϕ, ψ=sis.ψ; kw...)
 end
 
 # neighbor j is susceptible -> does nothing

--- a/test/sis_small_tree.jl
+++ b/test/sis_small_tree.jl
@@ -110,35 +110,35 @@
         @test logl_bp ≈ logp
     end
 
-    ### Periodic version
-    bp = periodic_mpbp(sis)
-    rng = MersenneTwister(111)
-    X, _ = onesample(bp; rng)
-
-    draw_node_observations!(bp.ϕ, X, N, last_time=true; rng)
-
-    svd_trunc = TruncBondMax(10)
-    iterate!(bp, maxiter=10; svd_trunc, showprogress=false)
-
-    b_bp = beliefs(bp)
-    p_bp = [[bbb[2] for bbb in bb] for bb in b_bp]
-
-    p_exact, Z_exact = exact_prob(bp)
-    b_exact = exact_marginals(bp; p_exact)
-    p_ex = [[bbb[2] for bbb in bb] for bb in b_exact]
-
-    f_bethe = bethe_free_energy(bp)
-    Z_bp = exp(-f_bethe)
-
-    local f(x,i) = x-1
-
-    r_bp = autocorrelations(f, bp)
-    r_exact = exact_autocorrelations(f, bp; p_exact)
-
-    c_bp = autocovariances(f, bp)
-    c_exact = exact_autocovariances(f, bp; r = r_exact)
-
     @testset "SIS small tree - periodic" begin
+        bp = periodic_mpbp(sis)
+        rng = MersenneTwister(111)
+        X, _ = onesample(bp; rng)
+
+        reset!(bp; observations=true)
+        draw_node_observations!(bp.ϕ, X, N, last_time=true; rng)
+
+        svd_trunc = TruncBondMax(10)
+        iterate!(bp, maxiter=10; svd_trunc, showprogress=false)
+
+        b_bp = beliefs(bp)
+        p_bp = [[bbb[2] for bbb in bb] for bb in b_bp]
+
+        p_exact, Z_exact = exact_prob(bp)
+        b_exact = exact_marginals(bp; p_exact)
+        p_ex = [[bbb[2] for bbb in bb] for bb in b_exact]
+
+        f_bethe = bethe_free_energy(bp)
+        Z_bp = exp(-f_bethe)
+
+        local f(x,i) = x-1
+
+        r_bp = autocorrelations(f, bp)
+        r_exact = exact_autocorrelations(f, bp; p_exact)
+
+        c_bp = autocovariances(f, bp)
+        c_exact = exact_autocovariances(f, bp; r = r_exact)
+
         @test Z_exact ≈ Z_bp
         @test p_ex ≈ p_bp
         @test r_bp ≈ r_exact


### PR DESCRIPTION
`mpbp(sis::SIS)` and similar become quite slow for large graph sizes / long times. Profiling shows most of the time is spent at [this](https://github.com/stecrotti/MatrixProductBP.jl/blob/457068104f03d3e3fc8bb4d787def316733740c6/src/Models/epidemics/sis_bp.jl#L40) call to `deepcopy`. This PR eliminates it

Warning: let's check first that this doesn't break anything

## Benchmark
```
[crotti@sibyl MatrixProductBP]$ git checkout main
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
[crotti@sibyl MatrixProductBP]$ julia -e '
> using MatrixProductBP, MatrixProductBP.Models, Graphs, IndexedGraphs
> T = 10^3        # final time
> k = 3         # degree
> λ = 0.07      # rate of transmission
> ρ = 0.1       # rate of recovery
> γ = 0.2      # prob. of zero patient
> N = 5*10^3
> gg = random_regular_graph(N, k; seed=0)
> g = IndexedGraph(gg)
> sis = SIS(g, λ, ρ, T; γ)
> # run once for compilation
> bp = mpbp(sis)
> # measure runtime
> @time mpbp(sis)
> '
225.252552 seconds (160.36 M allocations: 9.850 GiB, 26.75% gc time)
[crotti@sibyl MatrixProductBP]$ 
[crotti@sibyl MatrixProductBP]$ git checkout no-copy
Switched to branch 'no-copy'
Your branch is up to date with 'origin/no-copy'.
[crotti@sibyl MatrixProductBP]$ 
[crotti@sibyl MatrixProductBP]$ julia -e '
> using MatrixProductBP, MatrixProductBP.Models, Graphs, IndexedGraphs
> T = 10^3        # final time
> k = 3         # degree
> λ = 0.07      # rate of transmission
> ρ = 0.1       # rate of recovery
> γ = 0.2      # prob. of zero patient
> N = 5*10^3
> gg = random_regular_graph(N, k; seed=0)
> g = IndexedGraph(gg)
> sis = SIS(g, λ, ρ, T; γ)
> # run once for compilation
> bp = mpbp(sis)
> # measure runtime
> @time mpbp(sis)
> '

 40.912102 seconds (140.32 M allocations: 6.984 GiB, 58.05% gc time)
```

shows more than x5 speed-up