### PR TITLE
Optimize computation of autocorrelations

### DIFF
--- a/src/mpbp.jl
+++ b/src/mpbp.jl
@@ -238,9 +238,9 @@ beliefs(bp::MPBP{G,F}) where {G,F} = marginals.(bp.b)
 
 beliefs_tu(bp::MPBP{G,F}) where {G,F} = twovar_marginals.(bp.b)
 
-expectation(f, p::Matrix{<:Real}) = sum(f(xi) * f(xj) * p[xi, xj] for xi in axes(p,1), xj in axes(p,2); init=0.0)
+expectation(f, p::AbstractMatrix{<:Number}) = sum(f(xi) * f(xj) * p[xi, xj] for xi in axes(p,1), xj in axes(p,2); init=0.0)
 
-expectation(f, p::Vector{<:Real}) = sum(f(xi) * p[xi] for xi in eachindex(p); init=0.0)
+expectation(f, p::AbstractVector{<:Number}) = sum(f(xi) * p[xi] for xi in eachindex(p); init=0.0)
 
 function autocorrelations(f, bp::MPBP; showprogress::Bool=false, sites=vertices(bp.g),
         maxdist = getT(bp))


### PR DESCRIPTION
Not sure why, but it's faster