### PR TITLE
render mpem3from2 less specialized

### DIFF
--- a/src/mpems.jl
+++ b/src/mpems.jl
@@ -155,7 +155,7 @@ function mpem2(B::PeriodicMPEM3{F}) where {F}
 end
 
 
-mpem3from2(::Type{MPEM2{F}}) where F = MPEM3
-mpem3from2(::Type{PeriodicMPEM2{F}}) where F = PeriodicMPEM3
+mpem3from2(::Type{<:MPEM2}) = MPEM3
+mpem3from2(::Type{<:PeriodicMPEM2}) = PeriodicMPEM3
 
 default_truncator(::Type{<:AbstractMPEM2}) = TruncThresh(1e-6)

--- a/src/stationary.jl
+++ b/src/stationary.jl
@@ -40,7 +40,7 @@ function mpem2(B::InfiniteUniformMPEM3{F}) where {F}
     return InfiniteUniformMPEM2{F}(D; z = B.z)
 end
 
-mpem3from2(::Type{InfiniteUniformMPEM2{F}}) where F = InfiniteUniformMPEM3
+mpem3from2(::Type{<:InfiniteUniformMPEM2}) = InfiniteUniformMPEM3
 
 
 #### Naive MPBP


### PR DESCRIPTION
Adapt for upcoming changes in `TensorTrains`, small and should be harmless.